### PR TITLE
Update Docker configurations and change server address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ COPY src ./src
 # Compile o aplicativo
 RUN cargo build --release
 
-# Use uma imagem mais leve para a execução
-FROM debian:buster-slim
+# Use a imagem oficial do Debian como base
+FROM debian:latest
+
+# Instale as dependências necessárias
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Copie o binário compilado do estágio anterior
 COPY --from=builder /usr/src/app/target/release/gorfe /usr/local/bin/gorfe

--- a/compose.yml
+++ b/compose.yml
@@ -5,4 +5,9 @@ services:
       - "4000:4000"
     environment:
       - RUST_LOG=info
-      
+    networks:
+      - gorfe-network
+
+networks:
+  gorfe-network:
+    driver: bridge

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ async fn main() {
     let app: Router = routes::create_router();
 
     // Define the address and port for the server
-    let addr: SocketAddr = SocketAddr::from(([127, 0, 0, 1], 4000));
+    let addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], 4000));
     println!("Server running at http://{}", addr);
 
     // Bind the server to the address and serve the application


### PR DESCRIPTION
Update the Docker configuration to use the latest Debian image and install necessary dependencies. Change the server address to allow external connections.