### PR TITLE
Refactor API services and reorganize imports

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,28 @@
 services:
-  api:
+  api1:
     image: ghcr.io/caiomaz/gorfe:latest
     ports:
       - "4000:4000"
+    environment:
+      - RUST_LOG=info
+      - SENTRY_DSN=${SENTRY_DSN}
+    networks:
+      - gorfe-network
+
+  api2:
+    image: ghcr.io/caiomaz/gorfe:latest
+    ports:
+      - "4001:4000"
+    environment:
+      - RUST_LOG=info
+      - SENTRY_DSN=${SENTRY_DSN}
+    networks:
+      - gorfe-network
+
+  api3:
+    image: ghcr.io/caiomaz/gorfe:latest
+    ports:
+      - "4002:4000"
     environment:
       - RUST_LOG=info
       - SENTRY_DSN=${SENTRY_DSN}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use axum::{Router, Server};
 use axum_prometheus::PrometheusMetricLayer;
+use dotenv::dotenv;
 use sentry::integrations::tracing::layer as sentry_layer;
+use std::env;
 use std::net::SocketAddr;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use std::env;
-use dotenv::dotenv;
 mod models;
 mod routes;
 mod services;


### PR DESCRIPTION
Refactor the API services in the `compose.yml` file to include multiple instances and reorganize imports in `main.rs` for improved clarity and structure.