### PR TITLE
Remove Prometheus integration and related services from configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ serde_json = "1.0"
 thiserror = "1.0"
 sentry = { version = "0.35.0", features = ["tracing"] }
 axum-extra = "0.3"
-axum-prometheus = "0.2"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 dotenv = "0.15"

--- a/compose.yml
+++ b/compose.yml
@@ -8,24 +8,6 @@ services:
       - SENTRY_DSN=${SENTRY_DSN}
     networks:
       - gorfe-network
-    
-  prometheus:
-    image: prom/prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    networks:
-      - gorfe-network
-
-  grafana:
-    image: grafana/grafana
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
-    networks:
-      - gorfe-network
 
   watchtower:
     image: containrrr/watchtower

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use axum::{Router, Server};
-use axum_prometheus::PrometheusMetricLayer;
 use dotenv::dotenv;
 use sentry::integrations::tracing::layer as sentry_layer;
 use std::env;
@@ -22,9 +21,7 @@ async fn main() {
 
     tracing::info!("Iniciando servidor...");
 
-    let prometheus_layer = PrometheusMetricLayer::new();
-
-    let app: Router = routes::create_router().layer(prometheus_layer);
+    let app: Router = routes::create_router();
 
     let addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], 4000));
     println!("Server running at http://{}", addr);


### PR DESCRIPTION
Eliminate Prometheus and Grafana from the configuration and codebase, simplifying the application setup.